### PR TITLE
Fixes viewing of web logs

### DIFF
--- a/bin/v-list-web-domain-accesslog
+++ b/bin/v-list-web-domain-accesslog
@@ -19,6 +19,10 @@ format=${4-shell}
 source $VESTA/func/main.sh
 source $VESTA/conf/vesta.conf
 
+# Additional argument formatting
+format_domain
+format_domain_idn
+
 # JSON list function
 json_list() {
     i=1

--- a/bin/v-list-web-domain-errorlog
+++ b/bin/v-list-web-domain-errorlog
@@ -19,6 +19,10 @@ format=${4-shell}
 source $VESTA/func/main.sh
 source $VESTA/conf/vesta.conf
 
+# Additional argument formatting
+format_domain
+format_domain_idn
+
 # JSON list function
 json_list() {
     i=1


### PR DESCRIPTION
fixes website log viewing on panel, the issue was caused by is_object_valid using the variable $domain_idn which was not set the domain was set on the variable $domain.

I could of just changed $domain_idn to $domain and that would of fixed it too but I've added format domain and format domain_id like most other scripts that accept domain as a arguments.