### PR TITLE
added localhost ipv6 to relay_from_hosts

### DIFF
--- a/install/os-configs/rhel/7/exim/exim.conf
+++ b/install/os-configs/rhel/7/exim/exim.conf
@@ -13,7 +13,7 @@ keep_environment =
 
 domainlist local_domains = dsearch;/etc/exim/domains/
 domainlist relay_to_domains = dsearch;/etc/exim/domains/
-hostlist relay_from_hosts = 127.0.0.1
+hostlist relay_from_hosts = 127.0.0.1 : ::::1/128
 hostlist whitelist = net-iplsearch;/etc/exim/white-blocks.conf
 hostlist spammers = net-iplsearch;/etc/exim/spam-blocks.conf
 no_local_from_check


### PR DESCRIPTION
need to also have ipv6 localhst range in relay_from_hosts , I was getting "rejected RCPT <>: relay not permitted" error without it